### PR TITLE
[CHORE] Add NVLINk PROF to the default metrics captured

### DIFF
--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -89,4 +89,6 @@ data:
       # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
       DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
       DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+      DCGM_FI_PROF_NVLINK_TX_BYTES,    gauge, The rate of data transmitted over NVLink - including both protocol headers and data payloads - in bytes per second.
+      DCGM_FI_PROF_NVLINK_RX_BYTES,    gauge, The rate of data received over NVLink - including both protocol headers and data payloads - in bytes per second.
 {{- end }}

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -89,3 +89,5 @@ DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interf
 # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
 DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
 DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_NVLINK_TX_BYTES,    gauge, The rate of data transmitted over NVLink - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_NVLINK_RX_BYTES,    gauge, The rate of data received over NVLink - including both protocol headers and data payloads - in bytes per second.

--- a/tests/integration/testdata/default-counters.csv
+++ b/tests/integration/testdata/default-counters.csv
@@ -75,3 +75,13 @@ DCGM_FI_DRIVER_VERSION,        label, Driver Version
 # DCGM_FI_DEV_POWER_INFOROM_VER, label, Power management object inforom version
 # DCGM_FI_DEV_INFOROM_IMAGE_VER, label, Inforom image version
 # DCGM_FI_DEV_VBIOS_VERSION,     label, VBIOS version of the device
+
+# Datacenter Profiling (DCP) metrics
+# NOTE: supported on Nvidia datacenter Volta GPUs and newer
+DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.
+DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active.
+DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data.
+DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_NVLINK_TX_BYTES,    gauge, The rate of data transmitted over NVLink - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_NVLINK_RX_BYTES,    gauge, The rate of data received over NVLink - including both protocol headers and data payloads - in bytes per second.


### PR DESCRIPTION
Add NVLINK read/transmit stats to the default metrics

* `DCGM_FI_PROF_NVLINK_TX_BYTES` - The total number of bytes of active NvLink tx (transmit) data including both header and payload.
* `DCGM_FI_PROF_NVLINK_RX_BYTES` - The total number of bytes of active NvLink rx (read) data including both header and payload.

ref: https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html#c.DCGM_FI_PROF_NVLINK_TX_BYTES