### PR TITLE
[CHORE] Added support for NVLink5 counters

### DIFF
--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -106,7 +106,8 @@ service:
   annotations: {}
 
 # Allows to control pod resources
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -129,7 +130,7 @@ serviceMonitor:
     #   action: replace
   metricRelabelings: []
     # - action: replace
-    #   regex: original_metrics_name 
+    #   regex: original_metrics_name
     #   replacement: new_metrics_name
     #   sourceLabels:
     #   - name
@@ -158,8 +159,8 @@ extraConfigMapVolumes:
     configMap:
       name: exporter-metrics-config-map
       items:
-      - key: metrics
-        path: default-counters.csv
+        - key: metrics
+          path: default-counters.csv
 
 extraVolumeMounts:
   - name: exporter-metrics-volume
@@ -237,37 +238,36 @@ debugDump:
 kubernetesDRA:
   enabled: false
 
-
 # Customized list of metrics to emit. Expected to be in the same format (CSV) as the default list.
 # Must be the complete list and is not additive. If unset, the default list will take effect.
 # customMetrics: |
   # Format
   # If line starts with a '#' it is considered a comment
   # DCGM FIELD, Prometheus metric type, help message
-  
+
   # Clocks
   # DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
   # DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
-  
+
   # Temperature
   # DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
   # DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
-  
+
   # Power
   # DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
   # DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
-  
+
   # PCIE
   # DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
   # DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
   # DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
-  
+
   # Utilization (the sample period varies depending on the product)
   # DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
   # DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
   # DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
   # DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
-  
+
   # Errors and violations
   # DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
   # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
@@ -276,22 +276,22 @@ kubernetesDRA:
   # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
   # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
   # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
-  
+
   # Memory usage
   # DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
   # DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
-  
+
   # ECC
   # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
   # DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
   # DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
   # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
-  
+
   # Retired pages
   # DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
   # DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
   # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
-  
+
   # NVLink
   # DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
   # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
@@ -299,15 +299,15 @@ kubernetesDRA:
   # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
   # DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
   # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
-  
+
   # VGPU License status
   # DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
-  
+
   # Remapped rows
   # DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
   # DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
   # DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
-  
+
   # DCP metrics
   # DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.
   # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned.
@@ -319,6 +319,28 @@ kubernetesDRA:
   # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
   # DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
   # DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+
+  # NVLink5 metrics & Counters
+  # DCGM_FI_DEV_NVLINK_COUNT_TX_PACKETS, counter, Total number of Tx packets on the link in NVLink5
+  # DCGM_FI_DEV_NVLINK_COUNT_TX_BYTES, counter, Total number of Tx bytes on the link in NVLink5
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_PACKETS, counter, Total number of Rx packets on the link in NVLink5
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_BYTES, counter, Total number of Rx bytes on the link in NVLink5
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_MALFORMED_PACKET_ERRORS, counter, Number of packets Rx on a link where packets are malformed
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_BUFFER_OVERRUN_ERRORS, counter, Number of packets that were discarded on Rx due to buffer overrun
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_ERRORS, counter, Total number of packets with errors Rx on a link
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_REMOTE_ERRORS, counter, Total number of packets Rx - stomp/EBP marker
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_GENERAL_ERRORS, counter, Total number of packets Rx with header mismatch
+  # DCGM_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS, counter, Total number of times that the count of local errors exceeded a threshold
+  # DCGM_FI_DEV_NVLINK_COUNT_TX_DISCARDS, counter, Total number of tx error packets that were discarded
+  # DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS, counter, Number of times link went from Up to recovery, succeeded and link came back up
+  # DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS, counter, Number of times link went from Up to recovery, failed and link was declared down
+  # DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS, counter, Number of times link went from Up to recovery, irrespective of the result
+  # DCGM_FI_DEV_NVLINK_COUNT_RX_SYMBOL_ERRORS, counter, Number of errors in rx symbols
+  # DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER, counter, BER for symbol errors - raw value
+  # DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER_FLOAT, counter, BER for symbol errors - decoded float
+  # DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER, counter, Effective BER for effective errors - raw value
+  # DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT, counter, Effective BER for effective errors - decoded float
+  # DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS, counter, Sum of the number of errors in each Nvlink packet
 
 livenessProbe:
   initialDelaySeconds: 45

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -106,8 +106,7 @@ service:
   annotations: {}
 
 # Allows to control pod resources
-resources:
-  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
GB200 will be using modern NVLink counters of type `DCGM_FI_DEV_NVLINK_COUNT*`

ref: https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html#c.DCGM_FI_DEV_NVLINK_COUNT_TX_PACKETS